### PR TITLE
Add revised benchmarking logic and results

### DIFF
--- a/docs/reference_throughput.md
+++ b/docs/reference_throughput.md
@@ -7,27 +7,13 @@ For consistency, we use a batch size of 8 and the maximum context length that th
 
 Entries that read NaN represent combinations where the node configuration does not have enough GPU memory for the training run to complete. An exception is gemma-2b, which currently does not support full-rank FSDP fine-tuning.
 
-All values in the table below represent the median training throughput in tokens per second across all training steps, aggregated across all GPU devices.
+All values in the table below represent the median training throughput in tokens/second across all training steps, aggregated across all GPU devices.
 
-|                                      | Llama-2-13b-hf | Llama-2-7b-hf | Mistral-7B-v0.1 | Mixtral-8x7B-Instruct-v0.1 | gemma-2b | opt-350m |
-| :----------------------------------- | -------------: | ------------: | --------------: | -------------------------: | -------: | -------: |
-| (full_rank) NVIDIA A100-SXM4-80GB x1 |        424.726 |       570.818 |         528.747 |                        nan |      nan |  780.045 |
-| (full_rank) NVIDIA A100-SXM4-80GB x2 |        660.355 |        919.19 |         794.566 |                    275.459 |      nan |  1227.67 |
-| (full_rank) NVIDIA A100-SXM4-80GB x4 |         1309.4 |       1744.39 |         1577.09 |                    817.162 |      nan |  2181.46 |
-| (full_rank) NVIDIA A40 x1            |            nan |       47.6435 |         107.503 |                        nan |      nan |  666.881 |
-| (full_rank) NVIDIA A40 x2            |            nan |       313.074 |         322.624 |                        nan |      nan |  854.672 |
-| (full_rank) NVIDIA A40 x4            |         345.96 |       570.977 |         553.658 |                        nan |      nan |  1765.49 |
-| (full_rank) Tesla T4 x1              |            nan |           nan |             nan |                        nan |      nan |   475.51 |
-| (full_rank) Tesla T4 x2              |            nan |           nan |             nan |                        nan |      nan |  768.008 |
-| (full_rank) Tesla T4 x4              |            nan |           nan |             nan |                        nan |      nan |   1383.6 |
-| (full_rank) Tesla T4 x8              |            nan |           nan |             nan |                        nan |      nan |  2414.68 |
-| (lora) NVIDIA A100-SXM4-80GB x1      |        560.167 |       646.801 |         525.802 |                        nan |  851.678 |  859.379 |
-| (lora) NVIDIA A100-SXM4-80GB x2      |        871.993 |       1157.17 |         1105.68 |                    239.431 |  1724.57 |  1463.82 |
-| (lora) NVIDIA A100-SXM4-80GB x4      |        1783.53 |       2091.03 |         2150.06 |                    1309.74 |  2719.24 |  2381.01 |
-| (lora) NVIDIA A40 x1                 |        272.931 |       435.386 |         336.507 |                        nan |  983.256 |  652.611 |
-| (lora) NVIDIA A40 x2                 |        105.442 |       457.183 |         356.263 |                        nan |  725.723 |  1136.17 |
-| (lora) NVIDIA A40 x4                 |         543.22 |       715.416 |         642.642 |                        nan |  1302.62 |  1647.57 |
-| (lora) Tesla T4 x1                   |            nan |           nan |             nan |                        nan |  148.272 |  571.471 |
-| (lora) Tesla T4 x2                   |            nan |       101.126 |         102.859 |                        nan |  256.534 |  811.159 |
-| (lora) Tesla T4 x4                   |            nan |       188.575 |         190.127 |                        nan |  495.755 |  1506.05 |
-| (lora) Tesla T4 x8                   |        196.709 |       372.375 |         351.361 |                        nan |   897.81 |  2945.86 |
+|                                      | Meta-Llama-3-8B (2048)   | Meta-Llama-3-8B (4096)   | Meta-Llama-3-8B (8192)   |
+|:-------------------------------------|:-------------------------|:-------------------------|:-------------------------|
+| (full_rank) NVIDIA A100-SXM4-80GB x1 | 3550.48 (batch: 8)       | 3461.64 (batch: 4)       | 3204.21 (batch: 2)       |
+| (full_rank) NVIDIA A100-SXM4-80GB x2 | 6346.00 (batch: 8)       | 6182.59 (batch: 4)       | 5772.91 (batch: 2)       |
+| (full_rank) NVIDIA A100-SXM4-80GB x4 | 12688.44 (batch: 8)      | 12249.74 (batch: 4)      | 11463.46 (batch: 2)      |
+| (lora) NVIDIA A100-SXM4-80GB x1      | 4079.28 (batch: 8)       | 3682.15 (batch: 4)       | 3528.93 (batch: 2)       |
+| (lora) NVIDIA A100-SXM4-80GB x2      | 7182.97 (batch: 8)       | 6955.58 (batch: 4)       | 6452.96 (batch: 2)       |
+| (lora) NVIDIA A100-SXM4-80GB x4      | 14299.47 (batch: 8)      | 13834.43 (batch: 4)      | 12769.23 (batch: 2)      |

--- a/docs/reference_throughput.md
+++ b/docs/reference_throughput.md
@@ -1,19 +1,36 @@
 # Reference Throughput
 
 We've benchmarked VectorLM on the Vaughan cluster for a number of model architectures across a variety of node configurations.
-In experiments labelled as LoRA, we set hidden dimension to 8. During the testing, the NVIDIA driver version was 525.105.17, CUDA Runtime 12.1.105, and torch 2.2.2.
+In experiments labelled as LoRA, we set hidden dimension to 8. Below are version numbers of the testing environment:
 
-For consistency, we use a batch size of 8 and the maximum context length that the pre-trained LLM supports, capped at 65536. Note that especially for smaller models, it might be possible to further increase throughput by switching to a larger batch size.
+```bash
+$ pip3 freeze|grep -E "(torch|flash-attn|nvidia)"
+flash-attn==2.5.8
+nvidia-cublas-cu12==12.1.3.1
+nvidia-cuda-cupti-cu12==12.1.105
+nvidia-cuda-nvrtc-cu12==12.1.105
+nvidia-cuda-runtime-cu12==12.1.105
+nvidia-cudnn-cu12==8.9.2.26
+nvidia-cufft-cu12==11.0.2.54
+nvidia-curand-cu12==10.3.2.106
+nvidia-cusolver-cu12==11.4.5.107
+nvidia-cusparse-cu12==12.1.0.106
+nvidia-ml-py==12.550.52
+nvidia-nccl-cu12==2.19.3
+nvidia-nvjitlink-cu12==12.3.101
+nvidia-nvtx-cu12==12.1.105
+torch==2.2.1
+```
 
-Entries that read NaN represent combinations where the node configuration does not have enough GPU memory for the training run to complete. An exception is gemma-2b, which currently does not support full-rank FSDP fine-tuning.
+For each context width and hardware configuration, we experiment with a per-device batch size of 2, 4, and 8. In the table below, we report the batch size that maximizes training throughput. All values in the table represent the median training throughput in tokens/second across all training steps, aggregated across all GPU devices.
 
-All values in the table below represent the median training throughput in tokens/second across all training steps, aggregated across all GPU devices.
+|                                      | Meta-Llama-3-8B (2048) | Meta-Llama-3-8B (4096) | Meta-Llama-3-8B (8192) |
+| :----------------------------------- | :--------------------- | :--------------------- | :--------------------- |
+| (full_rank) NVIDIA A100-SXM4-80GB x1 | 3550.48 (batch: 8)     | 3461.64 (batch: 4)     | 3204.21 (batch: 2)     |
+| (full_rank) NVIDIA A100-SXM4-80GB x2 | 6346.00 (batch: 8)     | 6182.59 (batch: 4)     | 5772.91 (batch: 2)     |
+| (full_rank) NVIDIA A100-SXM4-80GB x4 | 12688.44 (batch: 8)    | 12249.74 (batch: 4)    | 11463.46 (batch: 2)    |
+| (lora) NVIDIA A100-SXM4-80GB x1      | 4079.28 (batch: 8)     | 3682.15 (batch: 4)     | 3528.93 (batch: 2)     |
+| (lora) NVIDIA A100-SXM4-80GB x2      | 7182.97 (batch: 8)     | 6955.58 (batch: 4)     | 6452.96 (batch: 2)     |
+| (lora) NVIDIA A100-SXM4-80GB x4      | 14299.47 (batch: 8)    | 13834.43 (batch: 4)    | 12769.23 (batch: 2)    |
 
-|                                      | Meta-Llama-3-8B (2048)   | Meta-Llama-3-8B (4096)   | Meta-Llama-3-8B (8192)   |
-|:-------------------------------------|:-------------------------|:-------------------------|:-------------------------|
-| (full_rank) NVIDIA A100-SXM4-80GB x1 | 3550.48 (batch: 8)       | 3461.64 (batch: 4)       | 3204.21 (batch: 2)       |
-| (full_rank) NVIDIA A100-SXM4-80GB x2 | 6346.00 (batch: 8)       | 6182.59 (batch: 4)       | 5772.91 (batch: 2)       |
-| (full_rank) NVIDIA A100-SXM4-80GB x4 | 12688.44 (batch: 8)      | 12249.74 (batch: 4)      | 11463.46 (batch: 2)      |
-| (lora) NVIDIA A100-SXM4-80GB x1      | 4079.28 (batch: 8)       | 3682.15 (batch: 4)       | 3528.93 (batch: 2)       |
-| (lora) NVIDIA A100-SXM4-80GB x2      | 7182.97 (batch: 8)       | 6955.58 (batch: 4)       | 6452.96 (batch: 2)       |
-| (lora) NVIDIA A100-SXM4-80GB x4      | 14299.47 (batch: 8)      | 13834.43 (batch: 4)      | 12769.23 (batch: 2)      |
+We provide the tools for evaluating the throughput on different context windows and different hardware/model configuration. Refer to the profiling folder in this repository to get started.

--- a/profiling/README.md
+++ b/profiling/README.md
@@ -13,7 +13,7 @@ $ python3 launch_benchmark.py
 # to accept and automatically invoke the commands.
 ```
 
-After the SLURM jobs complete, profiler output can be found under `data/benchmark`. Invoke the following the to generate a Markdown summary of the results:
+After the SLURM jobs complete, profiler output can be found under `data/benchmark`. Invoke the following the to generate a Markdown summary of the results. If the benchmark results include multiple different batch sizes for each (model, context window, hardware) pair, the table would list the "optimal" batch size associated with the highest training throughput for this combination.
 
 ```bash
 $ python3 profiling/parse_benchmark.py --folder data/benchmark

--- a/profiling/benchmark.py
+++ b/profiling/benchmark.py
@@ -366,6 +366,10 @@ if __name__ == "__main__":
             max_length=args.max_length,
         )
 
+        print(
+            f"Sequence length: {dataset.max_length};"
+            f"Batch Size: {args.training_batch_size}",
+        )
         write_metrics("max_length", dataset.max_length)
 
     # instantiate trainer

--- a/profiling/configs/benchmark.yaml
+++ b/profiling/configs/benchmark.yaml
@@ -6,7 +6,6 @@ wandb_config:
 
 train_parameters:
   output_dir: /dev/shm/lora-benchmark
-  max_seq_len: 128
   epochs: 1
   seed: 11
 

--- a/profiling/configs/lora-benchmark.yaml
+++ b/profiling/configs/lora-benchmark.yaml
@@ -6,7 +6,6 @@ wandb_config:
 
 train_parameters:
   output_dir: /dev/shm/lora-benchmark
-  max_seq_len: 128
   epochs: 1
   seed: 11
 

--- a/profiling/launch_benchmark.py
+++ b/profiling/launch_benchmark.py
@@ -25,6 +25,7 @@ model_list = [
         "opt-350m",
         "gemma-2b",
         "Llama-2-7b-hf",
+        "Meta-Llama-3-8B",
         "Llama-2-13b-hf",
         "Mistral-7B-v0.1",
         "Mixtral-8x7B-Instruct-v0.1",
@@ -37,8 +38,8 @@ config_list = [
 ]
 
 # Set to (-1) to fall back to the max context length of the pre-trained model.
-max_length_list = [1024, 2048, 4096, -1]
-batch_size = [8, 16, 32, 64, 128]
+max_length_list = [1024, 2048, -1]
+batch_size = [8, 32, 128]
 
 slurm_flags_options = {
     "nodes": [1],

--- a/profiling/launch_benchmark.py
+++ b/profiling/launch_benchmark.py
@@ -38,19 +38,20 @@ config_list = [
 ]
 
 # Set to (-1) to fall back to the max context length of the pre-trained model.
-max_length_list = [-1]
-per_device_train_batch_size = [2, 4, 8]
+max_length_list = [8192, 4096, 2048]
+# Per-device batch size for training
+per_device_batch_size = [2, 4, 8]
 
 slurm_flags_options = {
     "nodes": [1],
     "mem-per-gpu": ["16GB"],
     "ntasks-per-node": [1],
     "cpus-per-gpu": [3],
-    "gres": [f"gpu:{n}" for n in [1, 2, 4]],
+    "gres": [f"gpu:{n}" for n in [4, 2, 1]],
     "partition": partitions,
 }
 
-num_repeats = 2
+num_repeats = 1
 slurm_flags_extra = {"time": "01:00:00", "qos": qos_selected}
 
 slurm_pos_args_options = [
@@ -58,7 +59,7 @@ slurm_pos_args_options = [
     config_list,
     model_list,
     max_length_list,
-    per_device_train_batch_size,
+    per_device_batch_size,
 ]
 timestamp = int(time.time())
 

--- a/profiling/launch_benchmark.py
+++ b/profiling/launch_benchmark.py
@@ -22,13 +22,13 @@ partitions = launcher_args.partitions.split(",")
 model_list = [
     "/model-weights/" + model_name
     for model_name in [
-        "opt-350m",
-        "gemma-2b",
-        "Llama-2-7b-hf",
+        # "opt-350m",
+        # "gemma-2b",
+        # "Llama-2-7b-hf",
         "Meta-Llama-3-8B",
-        "Llama-2-13b-hf",
-        "Mistral-7B-v0.1",
-        "Mixtral-8x7B-Instruct-v0.1",
+        # "Llama-2-13b-hf",
+        # "Mistral-7B-v0.1",
+        # "Mixtral-8x7B-Instruct-v0.1",
     ]
 ]
 
@@ -38,15 +38,15 @@ config_list = [
 ]
 
 # Set to (-1) to fall back to the max context length of the pre-trained model.
-max_length_list = [1024, 2048, -1]
-batch_size = [8, 32, 128]
+max_length_list = [-1]
+per_device_train_batch_size = [2, 4, 8]
 
 slurm_flags_options = {
     "nodes": [1],
     "mem-per-gpu": ["16GB"],
     "ntasks-per-node": [1],
     "cpus-per-gpu": [3],
-    "gres": [f"gpu:{n}" for n in [1, 2, 4, 8]],
+    "gres": [f"gpu:{n}" for n in [1, 2, 4]],
     "partition": partitions,
 }
 
@@ -58,7 +58,7 @@ slurm_pos_args_options = [
     config_list,
     model_list,
     max_length_list,
-    batch_size,
+    per_device_train_batch_size,
 ]
 timestamp = int(time.time())
 

--- a/profiling/launch_benchmark.sh
+++ b/profiling/launch_benchmark.sh
@@ -28,7 +28,7 @@ profiling/benchmark.py \
 --yaml_path $1 \
 --model_name $2 \
 --max_length $3 \
---per_device_train_batch_size $4
+--per_device_batch_size $4
 
 # clean up benchmarking artifacts as ops have requested
 rm -rf /dev/shm/lora-benchmark

--- a/profiling/launch_benchmark.sh
+++ b/profiling/launch_benchmark.sh
@@ -28,7 +28,7 @@ profiling/benchmark.py \
 --yaml_path $1 \
 --model_name $2 \
 --max_length $3 \
---training_batch_size $4
+--per_device_train_batch_size $4
 
 # clean up benchmarking artifacts as ops have requested
 rm -rf /dev/shm/lora-benchmark


### PR DESCRIPTION
New features added in this pull request:

- benchmark.py now skips eval when benchmarking training throughput to ensure a consistent measure of throughput.
- When the experiment includes different batch sizes on the same hardware configuration, parse_benchmark.py would now report the batch size that maximizes median throughput for this model given the context window.
